### PR TITLE
Fix header: MuSE call generates a MuSe.txt file with incorrect filenames.

### DIFF
--- a/src/muse_call.cpp
+++ b/src/muse_call.cpp
@@ -1516,7 +1516,7 @@ void WriteHeader(PBLocalFile* outFile, int argc, char * const argv[], bam_hdr_t 
 				std::cerr << "Tumor BAM has no sample information.\n";
 				exit(-1);
 			}
-			outf += string("##TUMOR=\"Sample=") + kSM.s + ",File=" + argv[1] + "\"\n";
+			outf += string("##TUMOR=\"Sample=") + kSM.s + ",File=" + argv[argc-2] + "\"\n";
 			free(kSM.s);
 			break;
 		} else break;
@@ -1540,7 +1540,7 @@ void WriteHeader(PBLocalFile* outFile, int argc, char * const argv[], bam_hdr_t 
 				std::cerr << "Normal BAM has no sample information.\n";
 				exit(-1);
 			}
-			outf += string("##NORMAL=\"Sample=") + kSM.s + ",File=" + argv[2] + "\"\n";
+			outf += string("##NORMAL=\"Sample=") + kSM.s + ",File=" + argv[argc-1] + "\"\n";
 			free(kSM.s);
 			break;
 		} else break;


### PR DESCRIPTION
Current version of MuSE call generates a MuSe.txt file with incorrect filenames. Below is an example, where the filenames recorded for TUMOR and NORMAL are being pulled from first and second input parameters. 

```
##MuSE_call="MuSE -f /reference_files/GRCh38.d1.vd1/GRCh38.d1.vd1.fa -O pair1 call tumor1_paired.bwa.sorted.dedup.bqsr.bam normal1_paired.bwa.sorted.dedup.bqsr.bam"
##TUMOR="Sample=tumor1,File=-f"
##NORMAL="Sample=normal1,File=/reference_files/GRCh38.d1.vd1/GRCh38.d1.vd1.fa"
```

After applying the changes in this pull request the header output now shows:
```
##MuSE_call="MuSE -f /reference_files/GRCh38.d1.vd1/GRCh38.d1.vd1.fa -O pair1 call tumor1_paired.bwa.sorted.dedup.bqsr.bam normal1_paired.bwa.sorted.dedup.bqsr.bam"
##TUMOR="Sample=tumor1,File=tumor1_paired.bwa.sorted.dedup.bqsr.bam"
##NORMAL="Sample=normal1,File=normal1_paired.bwa.sorted.dedup.bqsr.bam"
```

Please consider this fix which uses an alternate index variable for `argv` in the `WriteHeader` function of `muse_call.cpp`.

