### PR TITLE
fixing missing hyphen before flag

### DIFF
--- a/install_muse.sh
+++ b/install_muse.sh
@@ -25,7 +25,7 @@ cd gperftools
 git checkout gperftools-2.9.1
 ./autogen.sh
 ./configure --libdir="$PWD"
-make j4
+make -j4
 make install
 cp libtcmalloc_minimal.a ../lib/
 cd ..


### PR DESCRIPTION
A call to `make j4` is made missing the `-` before the `j4` flag