### PR TITLE
including -ldeflate when building MuSE binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ COMMONFLAGS += $(INCLUDES)
 CXXFLAGS += $(COMMONFLAGS)
 CFLAGS += $(COMMONFLAGS)
 CPPFLAGS += $(COMMONFLAGS)
-COMMONLIBS= -Llib/ -lz -lm -lpthread -lbz2 -lcurl -lcrypto -llzma -fopenmp
+COMMONLIBS= -Llib/ -lz -lm -lpthread -lbz2 -lcurl -lcrypto -llzma -fopenmp -ldeflate
 
 #LIBS += $(COMMONLIBS) -ltcmalloc
 LIBS += $(COMMONLIBS)


### PR DESCRIPTION
not including -ldeflate caused the build to fail for me with errors about undefined references to functions in that library