### PR TITLE
Fix default processors to whats in the help message

### DIFF
--- a/src/main_muse.cpp
+++ b/src/main_muse.cpp
@@ -215,7 +215,7 @@ void get_MuseSumpOpts(int argc, char *argv[]){
     bool       isWGS        = false;
     bool       isWES        = false;
 
-    const char *threadNum_c = "0";
+    const char *threadNum_c = "1";
     int threadNum;
     // command options
     //


### PR DESCRIPTION
Line 241 says the default is 1 but the default is set to 0.  update the default value based on whats in the message.